### PR TITLE
Enable paths other than just root

### DIFF
--- a/deploy-multiple-regions.md
+++ b/deploy-multiple-regions.md
@@ -215,6 +215,7 @@ async function getSite(request, site) {
   request.headers.set('X-Forwarded-Host', url.hostname);
   request.headers.set('host', site);
   url.hostname = site;
+  url.protocol = "https:";
   response = fetch(url.toString(), request);
   console.log('Got getSite Request to ' + site, response);
   return response;


### PR DESCRIPTION
A number of things in the 'Deploying an application across multiple regions with a custom domain name' docs tripped me up and lead me to believe it wasn't working for me.

This PR fixes those things so other people don't get tripped up.

Fixes:
- Allows paths other than just root (eg. `ibmcloud-test.net/path` not just `ibmcloud-test.net/`)
- Allows a wider range of status codes to be seen as 'working', including all 2xx success requests and 3xx redirects.
- Like a good reverse proxy we are adding the X-Forwarded-Host header.
- Formatting of javascript was a little messy. Ran it through Prettier.