### PR TITLE
docs: typo and clarify which CMD you are refering

### DIFF
--- a/cmd-args.md
+++ b/cmd-args.md
@@ -24,13 +24,13 @@ For example, if your container image has an `Entrypoint` value of `/myapp` and a
 
 When you create a {{site.data.keyword.codeengineshort}} application or job, you can provide values for both the `Entrypoint` and `Command` arrays. 
 
-| Description    | Docker name    | {{site.data.keyword.codeengineshort}} name |
+| Description    | Image name    | {{site.data.keyword.codeengineshort}} name |
 | ---------- |  ------ | ------ | 
-| The command that is run by the container. | `ENTRYPOINT` | `command` |
-| The arguments that are passed to the command.    | `CMD`    | `args` |
+| The command that is run by the container. | `Entrypoint` | `command` |
+| The arguments that are passed to the command.    | `Command`    | `args` |
 {: caption="Docker and {{site.data.keyword.codeengineshort}} names" caption-side="bottom"}
 
-- If `--command` is used, then any image `Entrypoint` value is overwritten and any image `CMD` values are ignored.
+- If `--command` is used, then any image `Entrypoint` value is overwritten and any image `Command` values are ignored.
 - If `--argument` is used, then any image `Command` value is overwritten.
 
 

--- a/cmd-args.md
+++ b/cmd-args.md
@@ -30,15 +30,15 @@ When you create a {{site.data.keyword.codeengineshort}} application or job, you 
 | The arguments that are passed to the command.    | `CMD`    | `args` |
 {: caption="Docker and {{site.data.keyword.codeengineshort}} names" caption-side="bottom"}
 
-- If `--command` is used, then any image `Entrypoint` value is overwritten and any image `cmd` values are ignored.
-- If `--argument` is used, then any image `Command` value in overwritten.
+- If `--command` is used, then any image `Entrypoint` value is overwritten and any image `CMD` values are ignored.
+- If `--argument` is used, then any image `CMD` value is overwritten.
 
 
 
 
 To better understand this process, look at the following examples,
 
-| Image `Entrypoint` | Image `Cmd` |    {{site.data.keyword.codeengineshort}} `command` |    {{site.data.keyword.codeengineshort}} `args` |    Command that is run |
+| Image `Entrypoint` | Image `CMD` |    {{site.data.keyword.codeengineshort}} `command` |    {{site.data.keyword.codeengineshort}} `args` |    Command that is run |
 | ------ |  ------ | ------ | ------ | ------ |
 | `/myapp` |    `--debug` |    `<not set>` |    `<not set>` |    `/myapp --debug` |
 | `/myapp` |    `--debug` |    `/myapp2` |    `<not set>` |    `/myapp2` |

--- a/cmd-args.md
+++ b/cmd-args.md
@@ -38,7 +38,7 @@ When you create a {{site.data.keyword.codeengineshort}} application or job, you 
 
 To better understand this process, look at the following examples,
 
-| Image `Entrypoint` | Image `CMD` |    {{site.data.keyword.codeengineshort}} `command` |    {{site.data.keyword.codeengineshort}} `args` |    Command that is run |
+| Image `Entrypoint` | Image `Command` |    {{site.data.keyword.codeengineshort}} `command` |    {{site.data.keyword.codeengineshort}} `args` |    Command that is run |
 | ------ |  ------ | ------ | ------ | ------ |
 | `/myapp` |    `--debug` |    `<not set>` |    `<not set>` |    `/myapp --debug` |
 | `/myapp` |    `--debug` |    `/myapp2` |    `<not set>` |    `/myapp2` |

--- a/cmd-args.md
+++ b/cmd-args.md
@@ -31,7 +31,7 @@ When you create a {{site.data.keyword.codeengineshort}} application or job, you 
 {: caption="Docker and {{site.data.keyword.codeengineshort}} names" caption-side="bottom"}
 
 - If `--command` is used, then any image `Entrypoint` value is overwritten and any image `CMD` values are ignored.
-- If `--argument` is used, then any image `CMD` value is overwritten.
+- If `--argument` is used, then any image `Command` value is overwritten.
 
 
 


### PR DESCRIPTION
Its a bit confusing to use `Cmd` when you use `CMD` in the definition above. Updated to match.